### PR TITLE
Fix desktop app dev command in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ gif-clipper/
 ```bash
 cd desktop-app
 npm install
-npm run dev          # Start development mode
+npm start            # Start development mode
 npm run build        # Build for production
 npm run make         # Create distributable packages
 ```


### PR DESCRIPTION
## Summary
- Replace `npm run dev` with `npm start` in CLAUDE.md to match the actual script defined in `desktop-app/package.json`

## Test plan
- [ ] Verify `npm start` works in `desktop-app/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)