### PR TITLE
Add APP_BASE_URL env var for production share URLs

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -200,6 +200,12 @@ resource "digitalocean_app" "gif_clipper" {
         value = "production"
         type  = "GENERAL"
       }
+
+      env {
+        key   = "APP_BASE_URL"
+        value = var.api_custom_domain != "" ? "https://${var.api_custom_domain}" : "https://${digitalocean_app.gif_clipper.default_ingress}"
+        type  = "GENERAL"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `APP_BASE_URL` env var to terraform App Platform config
- Sets it to `https://gif.cartergrove.me` (the `api_custom_domain`)
- Fixes share URLs returned by the upload API defaulting to `http://localhost:8080`

## Root cause
`application.yml` defines `app.base-url: ${APP_BASE_URL:http://localhost:8080}` but the env var was never set in production. The GIF service uses this to build share URLs like `{baseUrl}/{gifId}`.

## Test plan
- [ ] Merge PR
- [ ] Run `terraform apply` to set the env var
- [ ] Upload a GIF and verify the share URL points to `gif.cartergrove.me`

🤖 Generated with [Claude Code](https://claude.com/claude-code)