### PR TITLE
Fix self-referential APP_BASE_URL in terraform

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -203,7 +203,7 @@ resource "digitalocean_app" "gif_clipper" {
 
       env {
         key   = "APP_BASE_URL"
-        value = var.api_custom_domain != "" ? "https://${var.api_custom_domain}" : "https://${digitalocean_app.gif_clipper.default_ingress}"
+        value = "https://${var.api_custom_domain}"
         type  = "GENERAL"
       }
     }


### PR DESCRIPTION
## Summary
- Fixes `Self-referential block` terraform error from PR #32
- Simplifies `APP_BASE_URL` to use `var.api_custom_domain` directly instead of referencing `digitalocean_app.gif_clipper.default_ingress`

## Test plan
- [ ] Merge and run `terraform apply` — should succeed without self-referential error
- [ ] Upload a GIF and verify share URL uses `gif.cartergrove.me`

🤖 Generated with [Claude Code](https://claude.com/claude-code)