### PR TITLE
Copy CDN URL to clipboard instead of share page URL

### DIFF
--- a/desktop-app/src/main/index.ts
+++ b/desktop-app/src/main/index.ts
@@ -159,12 +159,14 @@ const startCaptureWorkflow = async (): Promise<void> => {
       console.log('Uploading GIF...');
       const result = await uploadGif(gifPath, apiUrl);
 
-      // Validate URL before using it
+      // Validate URLs before using them
       const isValidUrl = /^https?:\/\//i.test(result.url);
+      const cdnUrl = result.cdnUrl || result.url;
+      const isValidCdnUrl = /^https?:\/\//i.test(cdnUrl);
 
-      // Copy URL to clipboard
-      if (store.get('upload.copyToClipboard', true) && isValidUrl) {
-        clipboard.writeText(result.url);
+      // Copy CDN URL to clipboard (direct link to the GIF file)
+      if (store.get('upload.copyToClipboard', true) && isValidCdnUrl) {
+        clipboard.writeText(cdnUrl);
       }
 
       // Show system notification


### PR DESCRIPTION
## Summary
- Clipboard now gets the CDN URL (direct GIF link, e.g. `cdn.cartergrove.me/...`) instead of the share page URL
- Browser still opens the share page when `openInBrowser` is enabled

## Test plan
- [ ] Capture a GIF and verify clipboard contains the CDN URL
- [ ] Verify pasting the URL loads the GIF directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)