### PR TITLE
Optimize GIF encoding with max width scaling and color limiting

### DIFF
--- a/desktop-app/src/main/encoder.ts
+++ b/desktop-app/src/main/encoder.ts
@@ -2,16 +2,30 @@ import { spawn } from 'child_process';
 import { unlink } from 'node:fs/promises';
 import { getFfmpegPath } from './ffmpeg-path';
 
-export function encodeGif(inputPath: string, fps: number): Promise<string> {
+export interface EncodingOptions {
+  colors: number;
+  maxWidth: number;
+}
+
+export function encodeGif(inputPath: string, fps: number, options: EncodingOptions): Promise<string> {
   return new Promise((resolve, reject) => {
     const outputPath = inputPath.replace(/\.[^.]+$/, '.gif');
+    const { colors, maxWidth } = options;
 
-    // Use split filter for optimal GIF quality:
-    // 1. palettegen analyzes all frames for best color palette
-    // 2. paletteuse applies that palette for high-quality output
+    // Build filter chain:
+    // 1. fps — resample to target frame rate
+    // 2. scale — downscale to maxWidth (never upscale), lanczos for quality
+    // 3. palettegen — generate optimal palette with limited colors
+    // 4. paletteuse — apply palette with bayer dithering (compresses well in GIF)
+    const filters = [
+      `fps=${fps}`,
+      `scale='min(iw,${maxWidth})':-1:flags=lanczos`,
+      `split[s0][s1];[s0]palettegen=max_colors=${colors}[p];[s1][p]paletteuse=dither=bayer:bayer_scale=5`,
+    ].join(',');
+
     const args = [
       '-i', inputPath,
-      '-vf', `fps=${fps},split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse`,
+      '-vf', filters,
       '-loop', '0',
       '-y',
       outputPath,

--- a/desktop-app/src/main/index.ts
+++ b/desktop-app/src/main/index.ts
@@ -149,8 +149,10 @@ const startCaptureWorkflow = async (): Promise<void> => {
   // Steps 4 & 5 run in the background — no UI blocking
   try {
     // Step 4: Encoding
-    console.log('Encoding GIF...');
-    const gifPath = await encodeGif(videoPath, fps);
+    const colors = store.get('encoding.colors', 128);
+    const maxWidth = store.get('encoding.maxWidth', 800);
+    console.log(`Encoding GIF (colors=${colors}, maxWidth=${maxWidth})...`);
+    const gifPath = await encodeGif(videoPath, fps, { colors, maxWidth });
     console.log(`GIF encoded: ${gifPath}`);
 
     // Step 5: Upload to backend

--- a/desktop-app/src/main/store.ts
+++ b/desktop-app/src/main/store.ts
@@ -16,6 +16,7 @@ export interface AppSettings {
   encoding: {
     quality: 'low' | 'medium' | 'high';
     colors: number;
+    maxWidth: number;
   };
   upload: {
     apiUrl: string;
@@ -40,7 +41,8 @@ const defaultSettings: AppSettings = {
   },
   encoding: {
     quality: 'high',
-    colors: 256,
+    colors: 128,
+    maxWidth: 800,
   },
   upload: {
     apiUrl: 'https://gif.cartergrove.me',
@@ -80,6 +82,7 @@ export const createStore = (): Store<AppSettings> => {
         properties: {
           quality: { type: 'string', enum: ['low', 'medium', 'high'] },
           colors: { type: 'number', minimum: 16, maximum: 256 },
+          maxWidth: { type: 'number', minimum: 320, maximum: 3840 },
         },
       },
       upload: {


### PR DESCRIPTION
## Summary
- **Max width scaling** (default 800px) — large captures are downscaled proportionally using lanczos resampling, never upscaled
- **Color palette limiting** — wires up the existing `colors` config (default changed from 256 to 128) to ffmpeg's `palettegen=max_colors`
- **Bayer dithering** — adds ordered dithering for better visual quality at reduced color counts; compresses better than floyd_steinberg in GIF format
- Expected file size reduction: **70–80%**

## Configuration
Users can tune via `config.json`:
```json
"encoding": {
  "colors": 128,
  "maxWidth": 800
}
```
- `colors`: 16–256 (fewer = smaller files, lower quality)
- `maxWidth`: 320–3840 (smaller = smaller files)

## Test plan
- [ ] Capture a large region (fullscreen on high-DPI) and compare file size to previous
- [ ] Verify quality is acceptable at 128 colors / 800px
- [ ] Test small capture (< 800px) is not upscaled
- [ ] Test with `colors: 256, maxWidth: 3840` for max quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)